### PR TITLE
Added prefixes to database tables

### DIFF
--- a/src/messenger/webim/install/dbinfo.php
+++ b/src/messenger/webim/install/dbinfo.php
@@ -20,7 +20,7 @@
  */
 
 $dbtables = array(
-	"chatgroup" => array(
+	$mysqlprefix . "chatgroup" => array(
 		"groupid" => "int NOT NULL auto_increment PRIMARY KEY",
 		"vcemail" => "varchar(64)",
 		"vclocalname" => "varchar(64) NOT NULL",
@@ -29,7 +29,7 @@ $dbtables = array(
 		"vccommondescription" => "varchar(1024) NOT NULL",
 	),
 
-	"chatthread" => array(
+	$mysqlprefix . "chatthread" => array(
 		"threadid" => "int NOT NULL auto_increment PRIMARY KEY",
 		"userName" => "varchar(64) NOT NULL",
 		"userid" => "varchar(255)",
@@ -51,12 +51,12 @@ $dbtables = array(
 		"shownmessageid" => "int NOT NULL DEFAULT 0",
 		"userAgent" => "varchar(255)",
 		"messageCount" => "varchar(16)",
-		"groupid" => "int references chatgroup(groupid)",
+		"groupid" => "int references " . $mysqlprefix . "chatgroup(groupid)",
 	),
 
-	"chatmessage" => array(
+	$mysqlprefix . "chatmessage" => array(
 		"messageid" => "int NOT NULL auto_increment PRIMARY KEY",
-		"threadid" => "int NOT NULL references chatthread(threadid)",
+		"threadid" => "int NOT NULL references " . $mysqlprefix . "chatthread(threadid)",
 		"ikind" => "int NOT NULL",
 		"agentId" => "int NOT NULL DEFAULT 0",
 		"tmessage" => "text NOT NULL",
@@ -64,7 +64,7 @@ $dbtables = array(
 		"tname" => "varchar(64)"
 	),
 
-	"chatoperator" => array(
+	$mysqlprefix . "chatoperator" => array(
 		"operatorid" => "int NOT NULL auto_increment PRIMARY KEY",
 		"vclogin" => "varchar(64) NOT NULL",
 		"vcpassword" => "varchar(64) NOT NULL",
@@ -81,16 +81,16 @@ $dbtables = array(
 		"vcrestoretoken" => "varchar(64)",
 	),
 
-	"chatrevision" => array(
+	$mysqlprefix . "chatrevision" => array(
 		"id" => "INT NOT NULL"
 	),
 
-	"chatgroupoperator" => array(
-		"groupid" => "int NOT NULL references chatgroup(groupid)",
-		"operatorid" => "int NOT NULL references chatoperator(operatorid)",
+	$mysqlprefix . "chatgroupoperator" => array(
+		"groupid" => "int NOT NULL references " . $mysqlprefix . "chatgroup(groupid)",
+		"operatorid" => "int NOT NULL references " . $mysqlprefix . "chatoperator(operatorid)",
 	),
 
-	"chatban" => array(
+	$mysqlprefix . "chatban" => array(
 		"banid" => "INT NOT NULL auto_increment PRIMARY KEY",
 		"dtmcreated" => "datetime DEFAULT 0",
 		"dtmtill" => "datetime DEFAULT 0",
@@ -99,20 +99,20 @@ $dbtables = array(
 		"blockedCount" => "int DEFAULT 0"
 	),
 
-	"chatconfig" => array (
+	$mysqlprefix . "chatconfig" => array (
 		"id" => "INT NOT NULL auto_increment PRIMARY KEY",
 		"vckey" => "varchar(255)",
 		"vcvalue" => "varchar(255)",
 	),
 
-	"chatresponses" => array(
+	$mysqlprefix . "chatresponses" => array(
 		"id" => "INT NOT NULL auto_increment PRIMARY KEY",
 		"locale" => "varchar(8)",
-		"groupid" => "int references chatgroup(groupid)",
+		"groupid" => "int references " . $mysqlprefix . "chatgroup(groupid)",
 		"vcvalue" => "varchar(1024) NOT NULL",
 	),
 	
-	"chatnotification" => array(
+	$mysqlprefix . "chatnotification" => array(
 		"id" => "INT NOT NULL auto_increment PRIMARY KEY",
 		"locale" => "varchar(8)",
 		"vckind" => "varchar(16)",
@@ -120,21 +120,21 @@ $dbtables = array(
 		"dtmcreated" => "datetime DEFAULT 0",
 		"vcsubject" => "varchar(256)",
 		"tmessage" => "text NOT NULL",
-		"refoperator" => "int NOT NULL references chatoperator(operatorid)",
+		"refoperator" => "int NOT NULL references " . $mysqlprefix . "chatoperator(operatorid)",
 	),
 );
 
 $memtables = array();
 
 $dbtables_can_update = array(
-	"chatthread" => array("agentId", "userTyping", "agentTyping", "messageCount", "nextagent", "shownmessageid", "userid", "userAgent", "groupid"),
-	"chatmessage" => array("agentId"),
-	"chatoperator" => array("vcavatar", "vcjabbername", "iperm", "istatus", "vcemail", "dtmrestore", "vcrestoretoken", "inotify"),
-	"chatban" => array(),
-	"chatgroup" => array("vcemail"),
-	"chatgroupoperator" => array(),
-	"chatresponses" => array(),
-	"chatnotification" => array(),
+	$mysqlprefix . "chatthread" => array("agentId", "userTyping", "agentTyping", "messageCount", "nextagent", "shownmessageid", "userid", "userAgent", "groupid"),
+	$mysqlprefix . "chatmessage" => array("agentId"),
+	$mysqlprefix . "chatoperator" => array("vcavatar", "vcjabbername", "iperm", "istatus", "vcemail", "dtmrestore", "vcrestoretoken", "inotify"),
+	$mysqlprefix . "chatban" => array(),
+	$mysqlprefix . "chatgroup" => array("vcemail"),
+	$mysqlprefix . "chatgroupoperator" => array(),
+	$mysqlprefix . "chatresponses" => array(),
+	$mysqlprefix . "chatnotification" => array(),
 );
 
 function show_install_err($text) {
@@ -150,7 +150,7 @@ function show_install_err($text) {
 }
 
 function create_table($id,$link) {
-	global $dbtables, $memtables, $dbencoding;
+	global $dbtables, $memtables, $dbencoding, $mysqlprefix;
 
 	if(!isset($dbtables[$id])) {
 		show_install_err("Unknown table: $id, ".mysql_error());
@@ -173,10 +173,10 @@ function create_table($id,$link) {
 
 	mysql_query($query,$link) or show_install_err(' Query failed: '.mysql_error());
 
-	if( $id == 'chatoperator' ) {
+	if( $id == $mysqlprefix . 'chatoperator' ) {
 		create_operator_("admin", "", "", "", "Administrator", "Administrator", 0, $link);
-	} else if( $id == 'chatrevision' ) {
-		perform_query("INSERT INTO chatrevision VALUES (1)",$link);
+	} else if( $id == $mysqlprefix . 'chatrevision' ) {
+		perform_query("INSERT INTO " . $mysqlprefix . "chatrevision VALUES (1)",$link);
 	}
 }
 

--- a/src/messenger/webim/install/dbperform.php
+++ b/src/messenger/webim/install/dbperform.php
@@ -77,90 +77,90 @@ if ($act == "silentcreateall") {
 			}
 		}
 
-		if( in_array("chatmessage.agentId", $absent) ) {
-			runsql("ALTER TABLE chatmessage ADD agentId int NOT NULL DEFAULT 0 AFTER ikind", $link);
-			runsql("update chatmessage,chatoperator set agentId = operatorid where agentId = 0 AND ikind = 2 AND (vclocalename = tname OR vccommonname = tname)", $link);
+		if( in_array($mysqlprefix . "chatmessage.agentId", $absent) ) {
+			runsql("ALTER TABLE " . $mysqlprefix . "chatmessage ADD agentId int NOT NULL DEFAULT 0 AFTER ikind", $link);
+			runsql("update " . $mysqlprefix . "chatmessage, " . $mysqlprefix . "chatoperator set agentId = operatorid where agentId = 0 AND ikind = 2 AND (vclocalename = tname OR vccommonname = tname)", $link);
 		}
 
-		if( in_array("chatthread.agentId", $absent) ) {
-			runsql("ALTER TABLE chatthread ADD agentId int NOT NULL DEFAULT 0 AFTER agentName", $link);
-			runsql("update chatthread,chatoperator set agentId = operatorid where agentId = 0 AND (vclocalename = agentName OR vccommonname = agentName)", $link);
+		if( in_array($mysqlprefix . "chatthread.agentId", $absent) ) {
+			runsql("ALTER TABLE " . $mysqlprefix . "chatthread ADD agentId int NOT NULL DEFAULT 0 AFTER agentName", $link);
+			runsql("update " . $mysqlprefix . "chatthread, " . $mysqlprefix . "chatoperator set agentId = operatorid where agentId = 0 AND (vclocalename = agentName OR vccommonname = agentName)", $link);
 		}
 
-		if( in_array("chatthread.agentTyping", $absent) ) {
-			runsql("ALTER TABLE chatthread ADD agentTyping int DEFAULT 0", $link);
+		if( in_array($mysqlprefix . "chatthread.agentTyping", $absent) ) {
+			runsql("ALTER TABLE " . $mysqlprefix . "chatthread ADD agentTyping int DEFAULT 0", $link);
 		}
 
-		if( in_array("chatthread.userTyping", $absent) ) {
-			runsql("ALTER TABLE chatthread ADD userTyping int DEFAULT 0", $link);
+		if( in_array($mysqlprefix . "chatthread.userTyping", $absent) ) {
+			runsql("ALTER TABLE " . $mysqlprefix . "chatthread ADD userTyping int DEFAULT 0", $link);
 		}
 
-		if( in_array("chatthread.messageCount", $absent) ) {
-			runsql("ALTER TABLE chatthread ADD messageCount varchar(16)", $link);
-			runsql("ALTER TABLE chatmessage ADD INDEX idx_threadid_ikind (threadid, ikind)", $link);
-			runsql("UPDATE chatthread t SET t.messageCount = (SELECT COUNT(*) FROM chatmessage WHERE chatmessage.threadid = t.threadid AND ikind = 1)", $link);
-			runsql("ALTER TABLE chatmessage DROP INDEX idx_threadid_ikind", $link);
+		if( in_array($mysqlprefix . "chatthread.messageCount", $absent) ) {
+			runsql("ALTER TABLE " . $mysqlprefix . "chatthread ADD messageCount varchar(16)", $link);
+			runsql("ALTER TABLE " . $mysqlprefix . "chatmessage ADD INDEX idx_threadid_ikind (threadid, ikind)", $link);
+			runsql("UPDATE " . $mysqlprefix . "chatthread t SET t.messageCount = (SELECT COUNT(*) FROM " . $mysqlprefix . "chatmessage WHERE " . $mysqlprefix . "chatmessage.threadid = t.threadid AND ikind = 1)", $link);
+			runsql("ALTER TABLE " . $mysqlprefix . "chatmessage DROP INDEX idx_threadid_ikind", $link);
 		}
 
-		if( in_array("chatthread.nextagent", $absent) ) {
-			runsql("ALTER TABLE chatthread ADD nextagent int NOT NULL DEFAULT 0", $link);
+		if( in_array($mysqlprefix . "chatthread.nextagent", $absent) ) {
+			runsql("ALTER TABLE " . $mysqlprefix . "chatthread ADD nextagent int NOT NULL DEFAULT 0", $link);
 		}
 
-		if( in_array("chatthread.shownmessageid", $absent) ) {
-			runsql("ALTER TABLE chatthread ADD shownmessageid int NOT NULL DEFAULT 0", $link);
+		if( in_array($mysqlprefix . "chatthread.shownmessageid", $absent) ) {
+			runsql("ALTER TABLE " . $mysqlprefix . "chatthread ADD shownmessageid int NOT NULL DEFAULT 0", $link);
 		}
 
-		if( in_array("chatthread.userid", $absent) ) {
-			runsql("ALTER TABLE chatthread ADD userid varchar(255) DEFAULT \"\"", $link);
+		if( in_array($mysqlprefix . "chatthread.userid", $absent) ) {
+			runsql("ALTER TABLE " . $mysqlprefix . "chatthread ADD userid varchar(255) DEFAULT \"\"", $link);
 		}
 
-		if( in_array("chatoperator.iperm", $absent) ) {
-			runsql("ALTER TABLE chatoperator ADD iperm int DEFAULT 65535", $link);
+		if( in_array($mysqlprefix . "chatoperator.iperm", $absent) ) {
+			runsql("ALTER TABLE " . $mysqlprefix . "chatoperator ADD iperm int DEFAULT 65535", $link);
 		}
 
-		if( in_array("chatoperator.istatus", $absent) ) {
-			runsql("ALTER TABLE chatoperator ADD istatus int DEFAULT 0", $link);
+		if( in_array($mysqlprefix . "chatoperator.istatus", $absent) ) {
+			runsql("ALTER TABLE " . $mysqlprefix . "chatoperator ADD istatus int DEFAULT 0", $link);
 		}
 
-		if( in_array("chatoperator.inotify", $absent) ) {
-			runsql("ALTER TABLE chatoperator ADD inotify int DEFAULT 0", $link);
+		if( in_array($mysqlprefix . "chatoperator.inotify", $absent) ) {
+			runsql("ALTER TABLE " . $mysqlprefix . "chatoperator ADD inotify int DEFAULT 0", $link);
 		}
 		
-		if( in_array("chatoperator.vcavatar", $absent) ) {
-			runsql("ALTER TABLE chatoperator ADD vcavatar varchar(255)", $link);
+		if( in_array($mysqlprefix . "chatoperator.vcavatar", $absent) ) {
+			runsql("ALTER TABLE " . $mysqlprefix . "chatoperator ADD vcavatar varchar(255)", $link);
 		}
 
-		if( in_array("chatoperator.vcjabbername", $absent) ) {
-			runsql("ALTER TABLE chatoperator ADD vcjabbername varchar(255)", $link);
+		if( in_array($mysqlprefix . "chatoperator.vcjabbername", $absent) ) {
+			runsql("ALTER TABLE " . $mysqlprefix . "chatoperator ADD vcjabbername varchar(255)", $link);
 		}
 
-		if( in_array("chatoperator.vcemail", $absent) ) {
-			runsql("ALTER TABLE chatoperator ADD vcemail varchar(64)", $link);
+		if( in_array($mysqlprefix . "chatoperator.vcemail", $absent) ) {
+			runsql("ALTER TABLE " . $mysqlprefix . "chatoperator ADD vcemail varchar(64)", $link);
 		}
 
-		if( in_array("chatoperator.dtmrestore", $absent) ) {
-			runsql("ALTER TABLE chatoperator ADD dtmrestore datetime DEFAULT 0", $link);
+		if( in_array($mysqlprefix . "chatoperator.dtmrestore", $absent) ) {
+			runsql("ALTER TABLE " . $mysqlprefix . "chatoperator ADD dtmrestore datetime DEFAULT 0", $link);
 		}
 
-		if( in_array("chatoperator.vcrestoretoken", $absent) ) {
-			runsql("ALTER TABLE chatoperator ADD vcrestoretoken varchar(64)", $link);
+		if( in_array($mysqlprefix . "chatoperator.vcrestoretoken", $absent) ) {
+			runsql("ALTER TABLE " . $mysqlprefix . "chatoperator ADD vcrestoretoken varchar(64)", $link);
 		}
 		
-		if( in_array("chatthread.groupid", $absent) ) {
-			runsql("ALTER TABLE chatthread ADD groupid int references chatgroup(groupid)", $link);
+		if( in_array($mysqlprefix . "chatthread.groupid", $absent) ) {
+			runsql("ALTER TABLE " . $mysqlprefix . "chatthread ADD groupid int references chatgroup(groupid)", $link);
 		}
 
-		if( in_array("chatthread.userAgent", $absent) ) {
-			runsql("ALTER TABLE chatthread ADD userAgent varchar(255)", $link);
+		if( in_array($mysqlprefix . "chatthread.userAgent", $absent) ) {
+			runsql("ALTER TABLE " . $mysqlprefix . "chatthread ADD userAgent varchar(255)", $link);
 		}
 
-		if( in_array("chatgroup.vcemail", $absent) ) {
-			runsql("ALTER TABLE chatgroup ADD vcemail varchar(64)", $link);
+		if( in_array($mysqlprefix . "chatgroup.vcemail", $absent) ) {
+			runsql("ALTER TABLE " . $mysqlprefix . "chatgroup ADD vcemail varchar(64)", $link);
 		}
 		
-		$res = mysql_query("select null from information_schema.statistics where table_name = 'chatmessage' and index_name = 'idx_agentid'", $link);
+		$res = mysql_query("select null from information_schema.statistics where table_name = '". $mysqlprefix . "chatmessage' and index_name = 'idx_agentid'", $link);
 		if($res && mysql_num_rows($res) == 0) {
-			runsql("ALTER TABLE chatmessage ADD INDEX idx_agentid (agentid)", $link);
+			runsql("ALTER TABLE " . $mysqlprefix . "chatmessage ADD INDEX idx_agentid (agentid)", $link);
 		}
 	}
 }

--- a/src/messenger/webim/libs/common.php
+++ b/src/messenger/webim/libs/common.php
@@ -359,9 +359,10 @@ function select_multi_assoc($query, $link) {
 }
 
 function db_build_select($fields, $table, $conditions, $orderandgroup) {
+	global $mysqlprefix;
 	$condition = count($conditions) > 0 ? " where ".implode(" and ", $conditions) : "";
 	if($orderandgroup) $orderandgroup = " ".$orderandgroup;
-	return "select $fields from $table$condition$orderandgroup";
+	return "select $fields from $mysqlprefix . $table$condition$orderandgroup";
 }	
 
 function db_rows_count($table,$conditions,$countfields, $link) {
@@ -594,13 +595,13 @@ $settingsloaded = false;
 $settings_in_db = array();
 
 function loadsettings_($link) {
-	global $settingsloaded, $settings_in_db, $settings;
+	global $settingsloaded, $settings_in_db, $settings, $mysqlprefix;
 	if($settingsloaded) {
 		return;
 	}
 	$settingsloaded = true;
 
-	$sqlresult = mysql_query('select vckey,vcvalue from chatconfig',$link) or die(' Query failed: '.mysql_error($link).": ".$query);
+	$sqlresult = mysql_query("select vckey,vcvalue from " . $mysqlprefix . "chatconfig",$link) or die(' Query failed: '.mysql_error($link).": ".$query);
 
 	while ($row = mysql_fetch_array($sqlresult, MYSQL_ASSOC)) {
 		$name = $row['vckey'];

--- a/src/messenger/webim/libs/common.php
+++ b/src/messenger/webim/libs/common.php
@@ -362,7 +362,7 @@ function db_build_select($fields, $table, $conditions, $orderandgroup) {
 	global $mysqlprefix;
 	$condition = count($conditions) > 0 ? " where ".implode(" and ", $conditions) : "";
 	if($orderandgroup) $orderandgroup = " ".$orderandgroup;
-	return "select $fields from $mysqlprefix . $table$condition$orderandgroup";
+	return "select $fields from $table$condition$orderandgroup";
 }	
 
 function db_rows_count($table,$conditions,$countfields, $link) {

--- a/src/messenger/webim/libs/config.php
+++ b/src/messenger/webim/libs/config.php
@@ -36,6 +36,7 @@ $mysqlhost = "localhost";
 $mysqldb = "webim_db";
 $mysqllogin = "webim_lite";
 $mysqlpass = "123";
+$mysqlprefix = "";
 
 $dbencoding = "utf8";
 $force_charset_in_connection = true;
@@ -50,6 +51,6 @@ $mail_encoding = "utf-8";
  *  Locales
  */
 $home_locale = "en";						/* native name will be used in this locale */
-$default_locale = "en";						/* if user does not provide known lang */
+$default_locale = "en";					/* if user does not provide known lang */
 
 ?>

--- a/src/messenger/webim/libs/groups.php
+++ b/src/messenger/webim/libs/groups.php
@@ -20,9 +20,10 @@
  */
 
 function group_by_id($id) {
+	global $mysqlprefix;
 	$link = connect();
 	$group = select_one_row(
-		 "select * from chatgroup where groupid = $id", $link );
+		 "select * from " . $mysqlprefix . "chatgroup where groupid = $id", $link );
 	mysql_close($link);
 	return $group;
 }
@@ -48,10 +49,10 @@ function setup_group_settings_tabs($gid, $active) {
 }
 
 function get_operator_groupslist($operatorid, $link) {
-	global $settings;
+	global $settings, $mysqlprefix;
 	if($settings['enablegroups'] == '1') {
 		$groupids = array(0);
-		$allgroups = select_multi_assoc("select groupid from chatgroupoperator where operatorid = $operatorid order by groupid",$link);
+		$allgroups = select_multi_assoc("select groupid from " . $mysqlprefix . "chatgroupoperator where operatorid = $operatorid order by groupid",$link);
 		foreach($allgroups as $g) {
 			$groupids[] = $g['groupid'];	
 		}

--- a/src/messenger/webim/libs/notify.php
+++ b/src/messenger/webim/libs/notify.php
@@ -20,8 +20,9 @@
  */
 
 function log_notification($locale,$kind,$to,$subj,$text,$refop,$link) {
+	global $mysqlprefix;
 	$query = sprintf(
-		"insert into chatnotification (locale,vckind,vcto,vcsubject,tmessage,refoperator,dtmcreated) values ('%s','%s','%s','%s','%s',%s,%s)",
+		"insert into " . $mysqlprefix . "chatnotification (locale,vckind,vcto,vcsubject,tmessage,refoperator,dtmcreated) values ('%s','%s','%s','%s','%s',%s,%s)",
 			$locale,
 			$kind,
 			mysql_real_escape_string($to,$link),

--- a/src/messenger/webim/libs/operator.php
+++ b/src/messenger/webim/libs/operator.php
@@ -34,24 +34,27 @@ $permission_ids = array(
 );
 
 function operator_by_login($login) {
+	global $mysqlprefix;
 	$link = connect();
 	$operator = select_one_row(
-		 "select * from chatoperator where vclogin = '".mysql_real_escape_string($login)."'", $link );
+		 "select * from " . $mysqlprefix . "chatoperator where vclogin = '".mysql_real_escape_string($login)."'", $link );
 	mysql_close($link);
 	return $operator;
 }
 
 function operator_by_email($mail) {
+	global $mysqlprefix;
 	$link = connect();
 	$operator = select_one_row(
-		 "select * from chatoperator where vcemail = '".mysql_real_escape_string($mail)."'", $link );
+		 "select * from " . $mysqlprefix . "chatoperator where vcemail = '".mysql_real_escape_string($mail)."'", $link );
 	mysql_close($link);
 	return $operator;
 }
 
 function operator_by_id_($id,$link) {
+	global $mysqlprefix;
 	return select_one_row(
-		 "select * from chatoperator where operatorid = $id", $link );
+		 "select * from " .$mysqlprefix . "chatoperator where operatorid = $id", $link );
 }
 
 function operator_by_id($id) {
@@ -62,10 +65,11 @@ function operator_by_id($id) {
 }
 
 function operator_get_all() {
+	global $mysqlprefix;
 	$link = connect();
 
 	$query = "select operatorid, vclogin, vclocalename, vccommonname, istatus, (unix_timestamp(CURRENT_TIMESTAMP)-unix_timestamp(dtmlastvisited)) as time ".
-			 "from chatoperator order by vclogin";
+			 "from " . $mysqlprefix . "chatoperator order by vclogin";
 	$operators = select_multi_assoc($query, $link);
 	mysql_close($link);
 	return $operators;
@@ -87,9 +91,10 @@ function operator_is_away($operator) {
 }
 
 function update_operator($operatorid,$login,$email,$jabber,$password,$localename,$commonname,$notify) {
+	global $mysqlprefix;
 	$link = connect();
 	$query = sprintf(
-		"update chatoperator set vclogin = '%s',%s vclocalename = '%s', vccommonname = '%s'".
+		"update " . $mysqlprefix . "chatoperator set vclogin = '%s',%s vclocalename = '%s', vccommonname = '%s'".
 		", vcemail = '%s', vcjabbername= '%s', inotify = %s".
 		" where operatorid = %s",
 		mysql_real_escape_string($login),
@@ -106,9 +111,10 @@ function update_operator($operatorid,$login,$email,$jabber,$password,$localename
 }
 
 function update_operator_avatar($operatorid,$avatar) {
+	global $mysqlprefix;
 	$link = connect();
 	$query = sprintf(
-		"update chatoperator set vcavatar = '%s' where operatorid = %s",
+		"update " . $mysqlprefix . "chatoperator set vcavatar = '%s' where operatorid = %s",
 		mysql_real_escape_string($avatar), $operatorid );
 
 	perform_query($query,$link);
@@ -116,8 +122,9 @@ function update_operator_avatar($operatorid,$avatar) {
 }
 
 function create_operator_($login,$email,$jabber,$password,$localename,$commonname,$notify,$link) {
+	global $mysqlprefix;
 	$query = sprintf(
-		"insert into chatoperator (vclogin,vcpassword,vclocalename,vccommonname,vcavatar,vcemail,vcjabbername,inotify) values ('%s','%s','%s','%s','%s','%s','%s',%s)",
+		"insert into " . $mysqlprefix . "chatoperator (vclogin,vcpassword,vclocalename,vccommonname,vcavatar,vcemail,vcjabbername,inotify) values ('%s','%s','%s','%s','%s','%s','%s',%s)",
 			mysql_real_escape_string($login),
 			md5($password),
 			mysql_real_escape_string($localename),
@@ -130,7 +137,7 @@ function create_operator_($login,$email,$jabber,$password,$localename,$commonnam
 	perform_query($query,$link);
 	$id = mysql_insert_id($link);
 
-	return select_one_row("select * from chatoperator where operatorid = $id", $link );
+	return select_one_row("select * from " . $mysqlprefix . "chatoperator where operatorid = $id", $link );
 }
 
 function create_operator($login,$email,$jabber,$password,$localename,$commonname,$notify) {
@@ -141,18 +148,20 @@ function create_operator($login,$email,$jabber,$password,$localename,$commonname
 }
 
 function notify_operator_alive($operatorid, $istatus) {
+	global $mysqlprefix;
 	$link = connect();
-	perform_query("update chatoperator set istatus = $istatus, dtmlastvisited = CURRENT_TIMESTAMP where operatorid = $operatorid",$link);
+	perform_query("update " . $mysqlprefix . "chatoperator set istatus = $istatus, dtmlastvisited = CURRENT_TIMESTAMP where operatorid = $operatorid",$link);
 	mysql_close($link);
 }
 
 function has_online_operators($groupid="") {
-	global $settings;
+	global $settings, $mysqlprefix;
 	loadsettings();
 	$link = connect();
-	$query = "select count(*) as total, min(unix_timestamp(CURRENT_TIMESTAMP)-unix_timestamp(dtmlastvisited)) as time from chatoperator";
+	$query = "select count(*) as total, min(unix_timestamp(CURRENT_TIMESTAMP)-unix_timestamp(dtmlastvisited)) as time from " . $mysqlprefix . "chatoperator";
 	if($groupid) {
-		$query .= ", chatgroupoperator where groupid = $groupid and chatoperator.operatorid = chatgroupoperator.operatorid and istatus = 0";
+		$query .= ", " . $mysqlprefix . "chatgroupoperator where groupid = $groupid and " . $mysqlprefix . "chatoperator.operatorid = " . 
+		$mysqlprefix . "chatgroupoperator.operatorid and istatus = 0";
 	} else {
 		$query .= " where istatus = 0";
 	}
@@ -162,10 +171,10 @@ function has_online_operators($groupid="") {
 }
 
 function is_operator_online($operatorid, $link) {
-	global $settings;
+	global $settings, $mysqlprefix;
 	loadsettings_($link);
 	$query = "select count(*) as total, min(unix_timestamp(CURRENT_TIMESTAMP)-unix_timestamp(dtmlastvisited)) as time ".
-			 "from chatoperator where operatorid = $operatorid";
+			 "from " . $mysqlprefix . "chatoperator where operatorid = $operatorid";
 	$row = select_one_row($query,$link);
 	return $row['time'] < $settings['online_timeout'] && $row['total'] == 1;
 }
@@ -237,7 +246,7 @@ function logout_operator() {
 }
 
 function setup_redirect_links($threadid,$token) {
-	global $page, $webimroot, $settings;
+	global $page, $webimroot, $settings, $mysqlprefix;
 	loadsettings();
 	$link = connect();
 
@@ -337,29 +346,35 @@ function prepare_menu($operator,$hasright=true) {
 }
 
 function get_all_groups($link) {
-	$query = "select chatgroup.groupid as groupid, vclocalname, vclocaldescription from chatgroup order by vclocalname";
+	global $mysqlprefix;
+	$query = "select " . $mysqlprefix . "chatgroup.groupid as groupid, vclocalname, vclocaldescription from " . $mysqlprefix . "chatgroup order by vclocalname";
 	return select_multi_assoc($query, $link);
 }
 
 function get_groups($link,$checkaway) {
-	$query = "select chatgroup.groupid as groupid, vclocalname, vclocaldescription".
-			", (SELECT count(*) from chatgroupoperator where chatgroup.groupid = chatgroupoperator.groupid) as inumofagents". 
+	global $mysqlprefix;
+	$query = "select " . $mysqlprefix . "chatgroup.groupid as groupid, vclocalname, vclocaldescription".
+			", (SELECT count(*) from " . $mysqlprefix . "chatgroupoperator where " . $mysqlprefix . "chatgroup.groupid = " . 
+			$mysqlprefix . "chatgroupoperator.groupid) as inumofagents". 
 			", (SELECT min(unix_timestamp(CURRENT_TIMESTAMP)-unix_timestamp(dtmlastvisited)) as time ".
-					"from chatgroupoperator, chatoperator where istatus = 0 and chatgroup.groupid = chatgroupoperator.groupid ".
-					"and chatgroupoperator.operatorid = chatoperator.operatorid) as ilastseen".
+					"from " . $mysqlprefix . "chatgroupoperator, " . $mysqlprefix . "chatoperator where istatus = 0 and " . 
+					$mysqlprefix . "chatgroup.groupid = " . $mysqlprefix . "chatgroupoperator.groupid ".
+					"and " . $mysqlprefix . "chatgroupoperator.operatorid = " . $mysqlprefix . "chatoperator.operatorid) as ilastseen".
 			($checkaway
 				 ? ", (SELECT min(unix_timestamp(CURRENT_TIMESTAMP)-unix_timestamp(dtmlastvisited)) as time ".
-						"from chatgroupoperator, chatoperator where istatus <> 0 and chatgroup.groupid = chatgroupoperator.groupid ".
-						"and chatgroupoperator.operatorid = chatoperator.operatorid) as ilastseenaway"
+						"from " . $mysqlprefix . "chatgroupoperator, " . $mysqlprefix . "chatoperator where istatus <> 0 and " . 
+						$mysqlprefix . "chatgroup.groupid = " . $mysqlprefix . "chatgroupoperator.groupid ".
+						"and " . $mysqlprefix . "chatgroupoperator.operatorid = " . $mysqlprefix . "chatoperator.operatorid) as ilastseenaway"
 				 : ""
 			 ).
-			 " from chatgroup order by vclocalname";
+			 " from " . $mysqlprefix . "chatgroup order by vclocalname";
 	return select_multi_assoc($query, $link);
 }
 
 function get_operator_groupids($operatorid) {
+	global $mysqlprefix;
 	$link = connect();
-	$query = "select groupid from chatgroupoperator where operatorid = $operatorid";
+	$query = "select groupid from " . $mysqlprefix . "chatgroupoperator where operatorid = $operatorid";
 	$result = select_multi_assoc($query, $link);
 	mysql_close($link);
 	return $result;

--- a/src/messenger/webim/libs/operator.php
+++ b/src/messenger/webim/libs/operator.php
@@ -250,7 +250,7 @@ function setup_redirect_links($threadid,$token) {
 	loadsettings();
 	$link = connect();
 
-	$operatorscount = db_rows_count("chatoperator", array(), "", $link);
+	$operatorscount = db_rows_count($mysqlprefix . "chatoperator", array(), "", $link);
 
 	$groupscount = 0;
 	if($settings['enablegroups'] == "1") {
@@ -270,7 +270,7 @@ function setup_redirect_links($threadid,$token) {
 
 	$operators = select_multi_assoc(db_build_select(
 		"operatorid, vclogin, vclocalename, vccommonname, istatus, (unix_timestamp(CURRENT_TIMESTAMP)-unix_timestamp(dtmlastvisited)) as time",
-		"chatoperator", array(), "order by vclogin $limit"), $link);
+		$mysqlprefix . "chatoperator", array(), "order by vclogin $limit"), $link);
 	
 	$groups = array_slice($groups, $p['start'], $p['end']-$p['start']);
 

--- a/src/messenger/webim/libs/operator.php
+++ b/src/messenger/webim/libs/operator.php
@@ -195,13 +195,13 @@ function append_query($link,$pv) {
 }
 
 function check_login($redirect=true) {
-	global $webimroot;
-	if( !isset( $_SESSION['operator'] ) ) {
+	global $webimroot, $mysqlprefix;
+	if( !isset( $_SESSION[$mysqlprefix . 'operator'] ) ) {
 		if( isset($_COOKIE['webim_lite']) ) {
 			list($login,$pwd) = preg_split("/,/", $_COOKIE['webim_lite'], 2);
 			$op = operator_by_login($login);
 			if( $op && isset($pwd) && isset($op['vcpassword']) && md5($op['vcpassword']) == $pwd ) {
-				$_SESSION['operator'] = $op;
+				$_SESSION[$mysqlprefix . 'operator'] = $op;
 				return $op;
 			}
 		}
@@ -217,16 +217,17 @@ function check_login($redirect=true) {
 			return null;
 		}
 	}
-	return $_SESSION['operator'];
+	return $_SESSION[$mysqlprefix . 'operator'];
 }
 
 function get_logged_in() {
-	return isset( $_SESSION['operator'] ) ? $_SESSION['operator'] : FALSE;
+	global $mysqlprefix;
+	return isset( $_SESSION[$mysqlprefix . 'operator'] ) ? $_SESSION[$mysqlprefix . 'operator'] : FALSE;
 }
 
 function login_operator($operator,$remember) {
-	global $webimroot;
-	$_SESSION['operator'] = $operator;
+	global $webimroot, $mysqlprefix;
+	$_SESSION[$mysqlprefix . 'operator'] = $operator;
 	if( $remember ) {
 		$value = $operator['vclogin'].",".md5($operator['vcpassword']);
 		setcookie('webim_lite', $value, time()+60*60*24*1000, "$webimroot/");
@@ -237,8 +238,8 @@ function login_operator($operator,$remember) {
 }
 
 function logout_operator() {
-	global $webimroot;
-	unset($_SESSION['operator']);
+	global $webimroot, $mysqlprefix;
+	unset($_SESSION[$mysqlprefix . 'operator']);
 	unset($_SESSION['backpath']);
 	if( isset($_COOKIE['webim_lite']) ) {
 		setcookie('webim_lite', '', time() - 3600, "$webimroot/");

--- a/src/messenger/webim/libs/settings.php
+++ b/src/messenger/webim/libs/settings.php
@@ -20,13 +20,13 @@
  */
 
 function update_settings() {
-	global $settings, $settings_in_db;
+	global $settings, $settings_in_db, $mysqlprefix;
 	$link = connect();
 	foreach ($settings as $key => $value) {
 		if(!isset($settings_in_db[$key])) {
-			perform_query("insert into chatconfig (vckey) values ('$key')",$link);
+			perform_query("insert into " . $mysqlprefix . "chatconfig (vckey) values ('$key')",$link);
 		}
-        $query = sprintf("update chatconfig set vcvalue='%s' where vckey='$key'", mysql_real_escape_string($value));
+        $query = sprintf("update " . $mysqlprefix . "chatconfig set vcvalue='%s' where vckey='$key'", mysql_real_escape_string($value));
 		perform_query($query,$link);
 	}
 

--- a/src/messenger/webim/operator/avatar.php
+++ b/src/messenger/webim/operator/avatar.php
@@ -77,8 +77,8 @@ if( !$op ) {
 	if(count($errors) == 0) {
 		update_operator_avatar($op['operatorid'],$avatar);
 
-		if ($opId && $avatar && $_SESSION['operator'] && $operator['operatorid'] == $opId) {
-			$_SESSION['operator']['vcavatar'] = $avatar;
+		if ($opId && $avatar && $_SESSION[$mysqlprefix . 'operator'] && $operator['operatorid'] == $opId) {
+			$_SESSION[$mysqlprefix . 'operator']['vcavatar'] = $avatar;
 		}
 		header("Location: $webimroot/operator/avatar.php?op=$opId");
 		exit;

--- a/src/messenger/webim/operator/ban.php
+++ b/src/messenger/webim/operator/ban.php
@@ -64,14 +64,14 @@ if( isset($_POST['address']) ) {
 		$utime = time() + $days * 24*60*60;
 		if (!$banId) {
 			$query = sprintf(
-				"insert into chatban (dtmcreated,dtmtill,address,comment) values (CURRENT_TIMESTAMP,%s,'%s','%s')",
+				"insert into " . $mysqlprefix . "chatban (dtmcreated,dtmtill,address,comment) values (CURRENT_TIMESTAMP,%s,'%s','%s')",
 				"FROM_UNIXTIME($utime)",
 				mysql_real_escape_string($address,$link),
 				mysql_real_escape_string($comment,$link));
 			perform_query($query,$link);
 		} else {
 			$query = sprintf(
-				"update chatban set dtmtill = %s,address = '%s',comment = '%s' where banid = $banId",
+				"update " . $mysqlprefix . "chatban set dtmtill = %s,address = '%s',comment = '%s' where banid = $banId",
 				"FROM_UNIXTIME($utime)",
 				mysql_real_escape_string($address,$link),
 				mysql_real_escape_string($comment,$link));
@@ -96,7 +96,7 @@ if( isset($_POST['address']) ) {
 } else if(isset($_GET['id'])) {
 	$banId = verifyparam( 'id', "/^\d{1,9}$/");
 	$link = connect();
-	$ban = select_one_row("select banid,(unix_timestamp(dtmtill)-unix_timestamp(CURRENT_TIMESTAMP)) as days,address,comment from chatban where banid = $banId", $link);
+	$ban = select_one_row("select banid,(unix_timestamp(dtmtill)-unix_timestamp(CURRENT_TIMESTAMP)) as days,address,comment from " . $mysqlprefix . "chatban where banid = $banId", $link);
 	mysql_close($link);
 
 	if( $ban ) {

--- a/src/messenger/webim/operator/blocked.php
+++ b/src/messenger/webim/operator/blocked.php
@@ -40,13 +40,13 @@ if( isset($_GET['act']) && $_GET['act'] == 'del' ) {
 	}
 
 	if( count($errors) == 0 ) {
-		perform_query("delete from chatban where banid = $banId",$link);
+		perform_query("delete from " . $mysqlprefix . "chatban where banid = $banId",$link);
 		header("Location: $webimroot/operator/blocked.php");
 		exit;
 	}
 }
 
-$result = mysql_query("select banid,unix_timestamp(dtmtill) as till,address,comment from chatban", $link)
+$result = mysql_query("select banid,unix_timestamp(dtmtill) as till,address,comment from " . $mysqlprefix . "chatban", $link)
 	or die(' Query failed: ' .mysql_error());
 
 $blockedList = array();

--- a/src/messenger/webim/operator/canned.php
+++ b/src/messenger/webim/operator/canned.php
@@ -32,8 +32,9 @@ $errors = array();
 $page = array();
 
 function load_canned_messages($locale, $groupid) {
+	global $mysqlprefix;
 	$link = connect();
-	$query = "select id, vcvalue from chatresponses ".
+	$query = "select id, vcvalue from " . $mysqlprefix . "chatresponses ".
 			 "where locale = '".$locale."' AND (".
 			 ($groupid 
 			 		? "groupid = $groupid" 
@@ -46,7 +47,7 @@ function load_canned_messages($locale, $groupid) {
 			$result[] = array('id' => '', 'vcvalue' => $answer);
 		}
 		if(count($result) > 0) {
-			$updatequery = "insert into chatresponses (vcvalue,locale,groupid) values ";
+			$updatequery = "insert into " . $mysqlprefix . "chatresponses (vcvalue,locale,groupid) values ";
 			for($i=0;$i<count($result);$i++) {
 				if($i > 0) {
 					$updatequery .= ", ";
@@ -109,7 +110,7 @@ if(isset($_GET['act']) && $_GET['act'] == 'delete') {
 
 	if( count($errors) == 0 ) {
 		$link = connect();
-		perform_query("delete from chatresponses where id = $key",$link);
+		perform_query("delete from " . $mysqlprefix . "chatresponses where id = $key",$link);
 		mysql_close($link);
 		header("Location: $webimroot/operator/canned.php?lang=$lang&group=$groupid");
 		exit;

--- a/src/messenger/webim/operator/cannededit.php
+++ b/src/messenger/webim/operator/cannededit.php
@@ -24,22 +24,25 @@ require_once('../libs/operator.php');
 require_once('../libs/pagination.php');
 
 function load_message($key) {
+	global $mysqlprefix;
 	$link = connect();
-	$result = select_one_row("select vcvalue from chatresponses where id = $key", $link);
+	$result = select_one_row("select vcvalue from " . $mysqlprefix . "chatresponses where id = $key", $link);
 	mysql_close($link);
 	return $result ? $result['vcvalue'] : null;
 }
 
 function save_message($key,$message) {
+	global $mysqlprefix;
 	$link = connect();
-	perform_query("update chatresponses set vcvalue = '".mysql_real_escape_string($message,$link)."' ".
+	perform_query("update " . $mysqlprefix . "chatresponses set vcvalue = '".mysql_real_escape_string($message,$link)."' ".
 				"where id = $key", $link);
 	mysql_close($link);
 }
 
 function add_message($locale,$groupid,$message) {
+	global $mysqlprefix;
 	$link = connect();
-	perform_query("insert into chatresponses (locale,groupid,vcvalue) values ('$locale',".
+	perform_query("insert into " . $mysqlprefix . "chatresponses (locale,groupid,vcvalue) values ('$locale',".
 				($groupid ? "$groupid, " : "null, ").
 				"'".mysql_real_escape_string($message,$link)."')", $link);
 	mysql_close($link);

--- a/src/messenger/webim/operator/group.php
+++ b/src/messenger/webim/operator/group.php
@@ -30,17 +30,19 @@ $errors = array();
 $groupid = '';
 
 function group_by_name($name) {
+	global $mysqlprefix;
 	$link = connect();
 	$group = select_one_row(
-		 "select * from chatgroup where vclocalname = '".mysql_real_escape_string($name)."'", $link );
+		 "select * from " . $mysqlprefix . "chatgroup where vclocalname = '".mysql_real_escape_string($name)."'", $link );
 	mysql_close($link);
 	return $group;
 }
 
 function create_group($name,$descr,$commonname,$commondescr) {
+	global $mysqlprefix;
 	$link = connect();
 	$query = sprintf(
-		"insert into chatgroup (vclocalname,vclocaldescription,vccommonname,vccommondescription) values ('%s','%s','%s','%s')",
+		"insert into " . $mysqlprefix . "chatgroup (vclocalname,vclocaldescription,vccommonname,vccommondescription) values ('%s','%s','%s','%s')",
 			mysql_real_escape_string($name),
 			mysql_real_escape_string($descr),
 			mysql_real_escape_string($commonname),
@@ -49,15 +51,16 @@ function create_group($name,$descr,$commonname,$commondescr) {
 	perform_query($query,$link);
 	$id = mysql_insert_id($link);
 
-	$newdep = select_one_row("select * from chatgroup where groupid = $id", $link );
+	$newdep = select_one_row("select * from " . $mysqlprefix . "chatgroup where groupid = $id", $link );
 	mysql_close($link);
 	return $newdep;
 }
 
 function update_group($groupid,$name,$descr,$commonname,$commondescr) {
+	global $mysqlprefix;
 	$link = connect();
 	$query = sprintf(
-		"update chatgroup set vclocalname = '%s', vclocaldescription = '%s', vccommonname = '%s', vccommondescription = '%s' where groupid = %s",
+		"update " . $mysqlprefix . "chatgroup set vclocalname = '%s', vclocaldescription = '%s', vccommonname = '%s', vccommondescription = '%s' where groupid = %s",
 		mysql_real_escape_string($name),
 		mysql_real_escape_string($descr),
 		mysql_real_escape_string($commonname),

--- a/src/messenger/webim/operator/groupmembers.php
+++ b/src/messenger/webim/operator/groupmembers.php
@@ -26,26 +26,29 @@ require_once('../libs/groups.php');
 $operator = check_login();
 
 function get_group_members($groupid) {
+	global $mysqlprefix;
 	$link = connect();
-	$query = "select operatorid from chatgroupoperator where groupid = $groupid";
+	$query = "select operatorid from " . $mysqlprefix . "chatgroupoperator where groupid = $groupid";
 	$result = select_multi_assoc($query, $link);
 	mysql_close($link);
 	return $result;
 }
 
 function update_group_members($groupid,$newvalue) {
+	global $mysqlprefix;
 	$link = connect();
-	perform_query("delete from chatgroupoperator where groupid = $groupid", $link);
+	perform_query("delete from " . $mysqlprefix . "chatgroupoperator where groupid = $groupid", $link);
 	foreach($newvalue as $opid) {
-		perform_query("insert into chatgroupoperator (groupid, operatorid) values ($groupid,$opid)", $link);
+		perform_query("insert into " . $mysqlprefix . "chatgroupoperator (groupid, operatorid) values ($groupid,$opid)", $link);
 	}
 	mysql_close($link);
 }
 
 function get_operators() {
+	global $mysqlprefix;
 	$link = connect();
 
-	$query = "select * from chatoperator order by vclogin";
+	$query = "select * from " . $mysqlprefix . "chatoperator order by vclogin";
 	$result = select_multi_assoc($query, $link);
 	mysql_close($link);
 	return $result;

--- a/src/messenger/webim/operator/groups.php
+++ b/src/messenger/webim/operator/groups.php
@@ -38,9 +38,9 @@ if( isset($_GET['act']) && $_GET['act'] == 'del' ) {
 	
 	if( count($errors) == 0 ) {
 		$link = connect();
-		perform_query("delete from chatgroup where groupid = $groupid",$link);
-		perform_query("delete from chatgroupoperator where groupid = $groupid",$link);
-		perform_query("update chatthread set groupid = 0 where groupid = $groupid",$link);
+		perform_query("delete from " . $mysqlprefix . "chatgroup where groupid = $groupid",$link);
+		perform_query("delete from " . $mysqlprefix . "chatgroupoperator where groupid = $groupid",$link);
+		perform_query("update " . $mysqlprefix . "chatthread set groupid = 0 where groupid = $groupid",$link);
 		mysql_close($link);
 		header("Location: $webimroot/operator/groups.php");
 		exit;

--- a/src/messenger/webim/operator/history.php
+++ b/src/messenger/webim/operator/history.php
@@ -36,8 +36,8 @@ $query = isset($_GET['q']) ? myiconv(getoutputenc(), $webim_encoding, $_GET['q']
 if($query !== false) {
 	$link = connect();
 	
-	$result = mysql_query("select chatgroup.groupid as groupid, vclocalname ".
-			 "from chatgroup order by vclocalname", $link);
+	$result = mysql_query("select " . $mysqlprefix . "chatgroup.groupid as groupid, vclocalname ".
+			 "from " . $mysqlprefix . "chatgroup order by vclocalname", $link);
 	$groupName = array();
 	while ($group = mysql_fetch_array($result, MYSQL_ASSOC)) {
 		$groupName[$group['groupid']] = $group['vclocalname'];
@@ -46,17 +46,17 @@ if($query !== false) {
 	$page['groupName'] = $groupName;
 	
 	$escapedQuery = mysql_real_escape_string($query,$link);
-	select_with_pagintation("DISTINCT unix_timestamp(chatthread.dtmcreated) as created, ".
-    	 "unix_timestamp(chatthread.dtmmodified) as modified, chatthread.threadid, ".
-		 "chatthread.remote, chatthread.agentName, chatthread.userName, groupid, ".
+	select_with_pagintation("DISTINCT unix_timestamp(" . $mysqlprefix . "chatthread.dtmcreated) as created, ".
+    	 "unix_timestamp(" . $mysqlprefix . "chatthread.dtmmodified) as modified, " . $mysqlprefix . "chatthread.threadid, ".
+		 $mysqlprefix . "chatthread.remote, " . $mysqlprefix . "chatthread.agentName, " . $mysqlprefix . "chatthread.userName, groupid, ".
 		 "messageCount as size",
-		 "chatthread, chatmessage",
+		 $mysqlprefix . "chatthread, " . $mysqlprefix . "chatmessage",
 		 array(
-		 	"chatmessage.threadid = chatthread.threadid",
-		 	"((chatthread.userName LIKE '%%$escapedQuery%%') or (chatmessage.tmessage LIKE '%%$escapedQuery%%'))"
+		 	$mysqlprefix . "chatmessage.threadid = " . $mysqlprefix . "chatthread.threadid",
+		 	"((" . $mysqlprefix . "chatthread.userName LIKE '%%$escapedQuery%%') or (" . $mysqlprefix . "chatmessage.tmessage LIKE '%%$escapedQuery%%'))"
 		 ),
 		 "order by created DESC",
-		 "DISTINCT chatthread.dtmcreated", $link);
+		 "DISTINCT " . $mysqlprefix . "chatthread.dtmcreated", $link);
 	
 	mysql_close($link);
 

--- a/src/messenger/webim/operator/notifications.php
+++ b/src/messenger/webim/operator/notifications.php
@@ -65,7 +65,7 @@ if($lang) {
 
 $link = connect();
 select_with_pagintation(
-	"id, locale, vckind, vcto, unix_timestamp(dtmcreated) as created, vcsubject, tmessage, refoperator", "chatnotification",
+	"id, locale, vckind, vcto, unix_timestamp(dtmcreated) as created, vcsubject, tmessage, refoperator", $mysqlprefix . "chatnotification",
 	$conditions,
 	"order by created desc", "", $link);
 

--- a/src/messenger/webim/operator/operators.php
+++ b/src/messenger/webim/operator/operators.php
@@ -50,8 +50,8 @@ if( isset($_GET['act']) && $_GET['act'] == 'del' ) {
 	
 	if( count($errors) == 0 ) {
 		$link = connect();
-		perform_query("delete from chatgroupoperator where operatorid = $operatorid",$link);
-		perform_query("delete from chatoperator where operatorid = $operatorid",$link);
+		perform_query("delete from " . $mysqlprefix . "chatgroupoperator where operatorid = $operatorid",$link);
+		perform_query("delete from " . $mysqlprefix . "chatoperator where operatorid = $operatorid",$link);
 		mysql_close($link);
 		
 		header("Location: $webimroot/operator/operators.php");

--- a/src/messenger/webim/operator/opgroups.php
+++ b/src/messenger/webim/operator/opgroups.php
@@ -26,10 +26,11 @@ require_once('../libs/operator_settings.php');
 $operator = check_login();
 
 function update_operator_groups($operatorid,$newvalue) {
+	global $mysqlprefix;
 	$link = connect();
-	perform_query("delete from chatgroupoperator where operatorid = $operatorid", $link);
+	perform_query("delete from " . $mysqlprefix . "chatgroupoperator where operatorid = $operatorid", $link);
 	foreach($newvalue as $groupid) {
-		perform_query("insert into chatgroupoperator (groupid, operatorid) values ($groupid,$operatorid)", $link);
+		perform_query("insert into " . $mysqlprefix . "chatgroupoperator (groupid, operatorid) values ($groupid,$operatorid)", $link);
 	}
 	mysql_close($link);
 }

--- a/src/messenger/webim/operator/permissions.php
+++ b/src/messenger/webim/operator/permissions.php
@@ -26,8 +26,9 @@ require_once('../libs/operator_settings.php');
 $operator = check_login();
 
 function update_operator_permissions($operatorid,$newvalue) {
+	global $mysqlprefix;
 	$link = connect();
-	$query = "update chatoperator set iperm = $newvalue where operatorid = $operatorid";
+	$query = "update " . $mysqlprefix . "chatoperator set iperm = $newvalue where operatorid = $operatorid";
 
 	perform_query($query,$link);
 	mysql_close($link);

--- a/src/messenger/webim/operator/permissions.php
+++ b/src/messenger/webim/operator/permissions.php
@@ -62,8 +62,8 @@ if( !$op ) {
 	if(count($errors) == 0) {
 		update_operator_permissions($op['operatorid'],$new_permissions);
 
-		if ($opId && $_SESSION['operator'] && $operator['operatorid'] == $opId) {
-			$_SESSION['operator']['iperm'] = $new_permissions;
+		if ($opId && $_SESSION[$mysqlprefix . 'operator'] && $operator['operatorid'] == $opId) {
+			$_SESSION[$mysqlprefix . $mysqlprefix . 'operator']['iperm'] = $new_permissions;
 		}
 		header("Location: $webimroot/operator/permissions.php?op=$opId&stored");
 		exit;

--- a/src/messenger/webim/operator/redirect.php
+++ b/src/messenger/webim/operator/redirect.php
@@ -69,7 +69,7 @@ if(isset($_GET['nextGroup'])) {
 			$link = connect();
 			$threadupdate = array("istate" => $state_waiting, "nextagent" => $nextid, "agentId" => 0);
 			if($thread['groupid'] != 0) {
-				if(FALSE === select_one_row("select groupid from chatgroupoperator where operatorid = $nextid and groupid = ".$thread['groupid'], $link)) {
+				if(FALSE === select_one_row("select groupid from " . $mysqlprefix . "chatgroupoperator where operatorid = $nextid and groupid = ".$thread['groupid'], $link)) {
 					$threadupdate['groupid'] = 0;
 				}
 			}

--- a/src/messenger/webim/operator/resetpwd.php
+++ b/src/messenger/webim/operator/resetpwd.php
@@ -53,7 +53,7 @@ if (count($errors) == 0 && isset($_POST['password'])) {
 		$page['isdone'] = true;
 
 		$link = connect();
-		$query = "update chatoperator set vcpassword = '".md5($password)."', vcrestoretoken = '' where operatorid = ".$opId;
+		$query = "update " . $mysqlprefix . "chatoperator set vcpassword = '".md5($password)."', vcrestoretoken = '' where operatorid = ".$opId;
 		perform_query($query, $link);
 		mysql_close($link);
 		

--- a/src/messenger/webim/operator/restore.php
+++ b/src/messenger/webim/operator/restore.php
@@ -45,7 +45,7 @@ if (isset($_POST['loginoremail'])) {
 		$token = md5((time() + microtime()).rand(0,99999999));
 		
 		$link = connect();
-		$query = "update chatoperator set dtmrestore = CURRENT_TIMESTAMP, vcrestoretoken = '$token' where operatorid = ".$torestore['operatorid'];
+		$query = "update " . $mysqlprefix . "chatoperator set dtmrestore = CURRENT_TIMESTAMP, vcrestoretoken = '$token' where operatorid = ".$torestore['operatorid'];
 		perform_query($query, $link);
 		
 		$href = get_app_location(true,false)."/operator/resetpwd.php?id=".$torestore['operatorid']."&token=$token";

--- a/src/messenger/webim/operator/statistics.php
+++ b/src/messenger/webim/operator/statistics.php
@@ -69,14 +69,14 @@ if( $start > $end ) {
 
 $link = connect();
 
-$page['reportByDate'] = select_multi_assoc("select DATE(dtmcreated) as date, COUNT(distinct threadid) as threads, SUM(chatmessage.ikind = $kind_agent) as agents, SUM(chatmessage.ikind = $kind_user) as users ".
-	 "from chatmessage where unix_timestamp(dtmcreated) >= $start AND unix_timestamp(dtmcreated) < $end group by DATE(dtmcreated) order by dtmcreated desc", $link);
+$page['reportByDate'] = select_multi_assoc("select DATE(dtmcreated) as date, COUNT(distinct threadid) as threads, SUM(" . $mysqlprefix . "chatmessage.ikind = $kind_agent) as agents, SUM(" . $mysqlprefix . "chatmessage.ikind = $kind_user) as users ".
+	 "from " . $mysqlprefix . "chatmessage where unix_timestamp(dtmcreated) >= $start AND unix_timestamp(dtmcreated) < $end group by DATE(dtmcreated) order by dtmcreated desc", $link);
 
-$page['reportByDateTotal'] = select_one_row("select COUNT(distinct threadid) as threads, SUM(chatmessage.ikind = $kind_agent) as agents, SUM(chatmessage.ikind = $kind_user) as users ".
-	 "from chatmessage where unix_timestamp(dtmcreated) >= $start AND unix_timestamp(dtmcreated) < $end", $link);
+$page['reportByDateTotal'] = select_one_row("select COUNT(distinct threadid) as threads, SUM(" . $mysqlprefix . "chatmessage.ikind = $kind_agent) as agents, SUM(" . $mysqlprefix . "chatmessage.ikind = $kind_user) as users ".
+	 "from " . $mysqlprefix . "chatmessage where unix_timestamp(dtmcreated) >= $start AND unix_timestamp(dtmcreated) < $end", $link);
 
 $page['reportByAgent'] = select_multi_assoc("select vclocalename as name, COUNT(distinct threadid) as threads, SUM(ikind = $kind_agent) as msgs, AVG(CHAR_LENGTH(tmessage)) as avglen ".
-	 "from chatmessage, chatoperator ".
+	 "from " . $mysqlprefix . "chatmessage, " . $mysqlprefix . "chatoperator ".
          "where agentId = operatorid AND unix_timestamp(dtmcreated) >= $start AND unix_timestamp(dtmcreated) < $end group by operatorid", $link);
 
 $page['showresults'] = count($errors) == 0;

--- a/src/messenger/webim/operator/threadprocessor.php
+++ b/src/messenger/webim/operator/threadprocessor.php
@@ -32,11 +32,12 @@ loadsettings();
 setlocale(LC_TIME, getstring("time.locale"));
 
 function thread_info($id) {
+	global $mysqlprefix;
 	$link = connect();
 	$thread = select_one_row("select userName,agentName,remote,userAgent,".
 			"unix_timestamp(dtmmodified) as modified, unix_timestamp(dtmcreated) as created,".
 			"vclocalname as groupName ".
-			"from chatthread left join chatgroup on chatthread.groupid = chatgroup.groupid ".
+			"from " . $mysqlprefix . "chatthread left join " . $mysqlprefix . "chatgroup on " . $mysqlprefix . "chatthread.groupid = " . $mysqlprefix . "chatgroup.groupid ".
 			"where threadid = ". $id, $link );
 	mysql_close($link);
 	return $thread;

--- a/src/messenger/webim/operator/update.php
+++ b/src/messenger/webim/operator/update.php
@@ -50,7 +50,7 @@ $threadstate_key = array(
 );
 
 function thread_to_xml($thread,$link) {
-	global $state_chatting, $threadstate_to_string, $threadstate_key,
+	global $state_chatting, $threadstate_to_string, $threadstate_key, $mysqlprefix,
 			$webim_encoding, $operator, $settings,
 			$can_viewthreads, $can_takeover;
 	$state = $threadstate_to_string[$thread['istate']];
@@ -101,7 +101,7 @@ function thread_to_xml($thread,$link) {
 	$userAgent = get_useragent_version($thread['userAgent']);
 	$result .= "<useragent>".$userAgent."</useragent>";
 	if( $thread["shownmessageid"] != 0 ) {
-		$query = "select tmessage from chatmessage where messageid = ".$thread["shownmessageid"];
+		$query = "select tmessage from " . $mysqlprefix . "chatmessage where messageid = ".$thread["shownmessageid"];
 		$line = select_one_row($query, $link);
 		if( $line ) {
 			$message = preg_replace("/[\r\n\t]+/", " ", $line["tmessage"]);
@@ -113,14 +113,14 @@ function thread_to_xml($thread,$link) {
 }
 
 function print_pending_threads($groupids,$since) {
-	global $webim_encoding, $settings, $state_closed, $state_left;
+	global $webim_encoding, $settings, $state_closed, $state_left, $mysqlprefix;
 	$link = connect();
 
 	$revision = $since;
 	$output = array();
 	$query = "select threadid, userName, agentName, unix_timestamp(dtmcreated), userTyping, ".
-			 "unix_timestamp(dtmmodified), lrevision, istate, remote, nextagent, agentId, userid, shownmessageid, userAgent, (select vclocalname from chatgroup where chatgroup.groupid = chatthread.groupid) as groupname ".
-			 "from chatthread where lrevision > $since ".
+			 "unix_timestamp(dtmmodified), lrevision, istate, remote, nextagent, agentId, userid, shownmessageid, userAgent, (select vclocalname from " . $mysqlprefix . "chatgroup where " . $mysqlprefix . "chatgroup.groupid = " . $mysqlprefix . "chatthread.groupid) as groupname ".
+			 "from " . $mysqlprefix . "chatthread where lrevision > $since ".
 			 ($since <= 0 
 			 		? "AND istate <> $state_closed AND istate <> $state_left " 
 			 		: "").

--- a/src/messenger/webim/operator/userhistory.php
+++ b/src/messenger/webim/operator/userhistory.php
@@ -38,6 +38,7 @@ if( isset($_GET['userid'])) {
 }
 
 function threads_by_userid($userid) {
+	global $mysqlprefix;
 	if ($userid == "") {
 	    return null;
 	}
@@ -45,7 +46,7 @@ function threads_by_userid($userid) {
 
 	$query = sprintf("select unix_timestamp(dtmcreated) as created, unix_timestamp(dtmmodified) as modified, ".
 			 " threadid, remote, agentName, userName ".
-			 "from chatthread ".
+			 "from " . $mysqlprefix . "chatthread ".
 			 "where userid=\"$userid\" order by created DESC", $userid);
 
 	$result = mysql_query($query, $link) or die(' Query failed: ' .mysql_error().": ".$query);


### PR DESCRIPTION
Added a variable in /libs/config.php that contains a prefix used on the table names, this allows for multiple installations of the chat in one database (the same way phpBB does)

This might still need a bit more testing, as I'm not familiar with the original code of mibew I might have missed something.
