### PR TITLE
tables indexes fix

### DIFF
--- a/src/messenger/webim/install/dbinfo.php
+++ b/src/messenger/webim/install/dbinfo.php
@@ -112,6 +112,12 @@ $dbtables = array(
 	)
 );
 
+$dbtables_indexes = array(
+	"${mysqlprefix}chatmessage" => array(
+		"idx_agentid" => "agentid"
+	)
+);
+
 $memtables = array();
 
 $dbtables_can_update = array(
@@ -139,7 +145,7 @@ function show_install_err($text)
 
 function create_table($id, $link)
 {
-	global $dbtables, $memtables, $dbencoding, $mysqlprefix;
+	global $dbtables, $dbtables_indexes, $memtables, $dbencoding, $mysqlprefix;
 
 	if (!isset($dbtables[$id])) {
 		show_install_err("Unknown table: $id, " . mysql_error($link));
@@ -150,6 +156,12 @@ function create_table($id, $link)
 			"(\n";
 	foreach ($dbtables[$id] as $k => $v) {
 		$query .= "	$k $v,\n";
+	}
+
+	if (isset($dbtables_indexes[$id])) {
+	    foreach ($dbtables_indexes[$id] as $k => $v) {
+		    $query .= "	INDEX $k ($v),\n";
+	    }
 	}
 
 	$query = preg_replace("/,\n$/", "", $query);

--- a/src/messenger/webim/install/dbperform.php
+++ b/src/messenger/webim/install/dbperform.php
@@ -154,7 +154,7 @@ if ($act == "silentcreateall") {
 			runsql("ALTER TABLE ${mysqlprefix}chatgroup ADD vcemail varchar(64)", $link);
 		}
 
-		$res = mysql_query("select null from information_schema.statistics where table_name = '${mysqlprefix}chatmessage' and index_name = 'idx_agentid'", $link);
+		$res = mysql_query("select null from information_schema.statistics where table_schema = '$mysqldb' and table_name = '${mysqlprefix}chatmessage' and index_name = 'idx_agentid'", $link);
 		if ($res && mysql_num_rows($res) == 0) {
 			runsql("ALTER TABLE ${mysqlprefix}chatmessage ADD INDEX idx_agentid (agentid)", $link);
 		}


### PR DESCRIPTION
Added indexes creation on install;
Added table name to the list of conditions when checking for index existance during database update (this is needed for several installations on one system with different databases and without any prefix for table names).
